### PR TITLE
docs: Add README and CONTRIBUTING files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ In order to contribute to project, you will first need to **set up your *pyro-ri
 -   We are going to get a local copy of the remote project (*fork*) and set remotes so we stay up to date to recent contributions.
 
     1.  **Create a fork** by clicking on the **fork button** on the current repository page
+
     2.  Clone *your* fork locally.
 
         ```shell
@@ -87,6 +88,7 @@ In order to contribute to project, you will first need to **set up your *pyro-ri
 <br>
 
 1.  Configure your fork `YOUR_USERNAME/pyro-risks` as `origin` remote
+
 2.  Configure `pyronear/pyro-risks repository` as `upstream` remote
 
     ```shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,178 @@
+# Contributing to the pyro-risks repository
+
+Everything you need to know to contribute efficiently to the project.
+
+
+## Codebase structure
+
+- [pyro-risks](https://github.com/pyronear/pyro-risks/tree/master/pyro_risks) - the pyro-risks library
+- [examples](https://github.com/pyronear/pyro-risks/tree/master/scripts) - examples scripts
+- [test](https://github.com/pyronear/pyro-vision/blob/master/test) - python unit tests
+
+
+## Continuous Integration
+
+This project uses the following integrations to ensure proper codebase maintenance:
+
+- [Github Actions](https://docs.github.com/en/free-pro-team@latest/actions/guides/about-continuous-integration) - run workflows for building and testing the package
+- [Codacy](https://www.codacy.com/) - analyzes commits for code quality
+- [Codecov](https://codecov.io/) - reports back coverage results
+
+As a contributor, you will only have to ensure coverage of your code by adding appropriate unit testing of your code.
+
+## Style conventions
+
+- **Code**:
+  - Setup the `__all__` special variable for each module
+  - Use type hints for every functions ([type hints cheat sheet](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html))
+  - Format your code using the [black](https://github.com/psf/black) auto-formatter
+  - Ensure to document your code using type hints compatible docstrings. In doing so, please follow [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) so it can ease the process of documentation later.
+
+- **Commit message**: please follow [Udacity guide](http://udacity.github.io/git-styleguide/)
+
+## Issues
+
+Use Github [issues](https://github.com/pyronear/pyro-risks/issues) for feature requests, or bug reporting. When doing so, use issue templates whenever possible and provide enough information for other contributors to jump in.
+
+## Code contribution
+
+In order to contribute to project, you will first need to **set up your *pyro-risks* development environment** and then follow the **contributing workflow** and the **code & commit guidelines**.
+
+* [Project Setup](#project-setup): *fork the project and install dependencies in a well-encapsulated development environment*
+ 
+    1. [**Create a virtual environment**](#1-create-a-virtual-environment) to avoid collision with our OS and other projects
+    2. [**Fork the pyro-risks project**](#2-fork-the-repository) to be able to start working on a local copy of the project
+    3. [**Set origin and upstream remotes**](#3-set-origin-and-upstream-remotes-repositories) repositories: 
+    4. [**Install project dependencies**](#4-install-project-dependencies)
+   
+* [Contributing workflow](#contributing-workflow): *pull remote changes/new contributions and push your contributions to the original project*
+
+* [Follow the repository style conventions](#style-conventions)
+
+### Project Setup
+---
+
+#### 1. Create a virtual environment
+
+  - We are going to create a python3.6 virtual environment dedicated to the `pyro-risks` project using [conda](https://docs.conda.io/en/latest/) as an environment management system. Please open a terminal and follow the instructions.
+
+    ```shell
+    conda create --name pyro-risks python=3.6 anaconda 
+    conda activate pyro-risks
+    ```
+
+#### 2. Fork the repository
+
+- We are going to get a local copy of the remote project (_fork_) and set remotes so we stay up to date to recent contributions.
+
+  1. **Create a fork** by clicking on the **fork button** on the current repository page
+  2. Clone _your_ fork locally.
+    ```shell
+    # change directory to one for the project
+    cd /path/to/local/pyronear/project/
+
+    # clone your fork. replace YOUR_USERNAME accordingly
+    git clone https://github.com/YOUR_USERNAME/pyro-risks.git
+
+    # cd to pyro-risks
+    cd pyro-risks
+    ```
+
+#### 3. Set origin and upstream remotes repositories
+
+1. Configure your fork `YOUR_USERNAME/pyro-risks` as `origin` remote
+2. Configure `pyronear/pyro-risks` repository as `upstream` remote
+
+    ```shell
+    # add the original repository as remote repository called "upstream"
+    git remote add upstream https://github.com/pyronear/pyro-risks.git
+
+    # verify repository has been correctly added
+    git remote -v
+
+    # fetch all changes from the upstream repository
+    git fetch upstream
+
+    # switch to the master branch of your fork
+    git checkout master
+
+    # merge changes from the upstream repository into your fork
+    git merge upstream/master
+    ```
+
+
+#### 4. Install project dependencies
+
+```shell
+# install dependencies
+pip install black
+pip install -r requirements.txt
+
+# install current project in editable mode,
+# so local changes will be reflected locally (ie:at import)
+pip install -e .
+```
+
+
+### Contributing workflow
+---
+Once the project is well set up, we are going to detail step by step a usual contributing workflow.
+
+1.  Merge recent contributions onto master (do this frequently to stay up-to-date)
+   
+    ```shell
+    # fetch all changes from the upstream repository
+    git fetch upstream
+
+    # switch to the master branch of your fork
+    git checkout master
+
+    # merge changes from the upstream repository into your fork
+    git merge upstream/master
+    ```
+
+    Note: Since, we are going to create features on separate local branches so they'll be merged onto **original project remote master** via pull requests, we may use **pulling** instead of fetching & merging. This way our **_local_ master branch** will reflect **_remote_ original project**. We don't expect to make changes on local master in this workflow so no conflict should arise when merging:
+
+    ```shell
+    # switch to local master
+    git checkout master
+
+    #  merge remote master of original project onto local master
+    git pull upstream/master
+    ```
+
+2. Create a local feature branch to work on
+
+    ```shell
+    # Create a new branch with the name of your feature
+    git checkout -b feature-branch
+    ```
+
+3. Commit your changes (remember to add unit tests for your code). Feel free to interactively rebase your history to improve readability. Follow the style guide See [Style Conventions](#style-conventions) to follow guidelines.
+
+4. Rebase your feature branch so that merging it will be a simple fast-forward that won't require any conflict resolution work.
+
+    ```shell
+    # Switch to feature branch
+    git checkout feature-branch
+
+    # Rebase on master
+    git rebase master
+    ```
+
+5. Push your changes on remote feature branch.
+    ```shell
+    git checkout feature-branch
+
+    # Push first time (we create remote branch at the same time)
+    git push -u origin feature-branch
+
+    # Next times, we simply push commits
+    git push origin
+    # Format your code with 
+    black /path/to/local/pyronear/project/pyro-risks/
+    ```
+
+6. When satisfied with your branch, open a [PR](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork) from your fork in order to integrate your contribution to original project.
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,33 +2,31 @@
 
 Everything you need to know to contribute efficiently to the project.
 
-
 ## Codebase structure
 
-- [pyro-risks](https://github.com/pyronear/pyro-risks/tree/master/pyro_risks) - the pyro-risks library
-- [examples](https://github.com/pyronear/pyro-risks/tree/master/scripts) - examples scripts
-- [test](https://github.com/pyronear/pyro-vision/blob/master/test) - python unit tests
-
+-   [pyro-risks](https://github.com/pyronear/pyro-risks/tree/master/pyro_risks) - the pyro-risks library
+-   [examples](https://github.com/pyronear/pyro-risks/tree/master/scripts) - examples scripts
+-   [test](https://github.com/pyronear/pyro-vision/blob/master/test) - python unit tests
 
 ## Continuous Integration
 
 This project uses the following integrations to ensure proper codebase maintenance:
 
-- [Github Actions](https://docs.github.com/en/free-pro-team@latest/actions/guides/about-continuous-integration) - run workflows for building and testing the package
-- [Codacy](https://www.codacy.com/) - analyzes commits for code quality
-- [Codecov](https://codecov.io/) - reports back coverage results
+-   [Github Actions](https://docs.github.com/en/free-pro-team@latest/actions/guides/about-continuous-integration) - run workflows for building and testing the package
+-   [Codacy](https://www.codacy.com/) - analyzes commits for code quality
+-   [Codecov](https://codecov.io/) - reports back coverage results
 
 As a contributor, you will only have to ensure coverage of your code by adding appropriate unit testing of your code.
 
 ## Style conventions
 
-- **Code**:
-  - Setup the `__all__` special variable for each module
-  - Use type hints for every functions ([type hints cheat sheet](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html))
-  - Format your code using the [black](https://github.com/psf/black) auto-formatter
-  - Ensure to document your code using type hints compatible docstrings. In doing so, please follow [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) so it can ease the process of documentation later.
+-   **Code**:
+    -   Setup the `__all__` special variable for each module
+    -   Use type hints for every functions ([type hints cheat sheet](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html))
+    -   Format your code using the [black](https://github.com/psf/black) auto-formatter
+    -   Ensure to document your code using type hints compatible docstrings. In doing so, please follow [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) so it can ease the process of documentation later.
 
-- **Commit message**: please follow [Udacity guide](http://udacity.github.io/git-styleguide/)
+-   **Commit message**: please follow [Udacity guide](http://udacity.github.io/git-styleguide/)
 
 ## Issues
 
@@ -38,23 +36,26 @@ Use Github [issues](https://github.com/pyronear/pyro-risks/issues) for feature r
 
 In order to contribute to project, you will first need to **set up your *pyro-risks* development environment** and then follow the **contributing workflow** and the **code & commit guidelines**.
 
-* [Project Setup](#project-setup): *fork the project and install dependencies in a well-encapsulated development environment*
- 
-    1. [**Create a virtual environment**](#1-create-a-virtual-environment) to avoid collision with our OS and other projects
-    2. [**Fork the pyro-risks project**](#2-fork-the-repository) to be able to start working on a local copy of the project
-    3. [**Set origin and upstream remotes**](#3-set-origin-and-upstream-remotes-repositories) repositories: 
-    4. [**Install project dependencies**](#4-install-project-dependencies)
-   
-* [Contributing workflow](#contributing-workflow): *pull remote changes/new contributions and push your contributions to the original project*
+-   [Project Setup](#project-setup): *fork the project and install dependencies in a well-encapsulated development environment*
 
-* [Follow the repository style conventions](#style-conventions)
+    1.  [**Create a virtual environment**](#create-a-virtual-environment) to avoid collision with our OS and other projects
+    2.  [**Fork the pyro-risks project**](#fork-the-repository) to be able to start working on a local copy of the project
+    3.  [**Set origin and upstream remotes**](#set-origin-and-upstream-remotes-repositories) repositories: 
+    4.  [**Install project dependencies**](#install-project-dependencies)
+
+-   [Contributing workflow](#contributing-workflow): *pull remote changes/new contributions and push your contributions to the original project*
+
+-   [Follow the repository style conventions](#style-conventions)
 
 ### Project Setup
----
+
+* * *
 
 #### 1. Create a virtual environment
 
-  - We are going to create a python3.6 virtual environment dedicated to the `pyro-risks` project using [conda](https://docs.conda.io/en/latest/) as an environment management system. Please open a terminal and follow the instructions.
+<br>
+
+-   We are going to create a python3.6 virtual environment dedicated to the `pyro-risks` project using [conda](https://docs.conda.io/en/latest/) as an environment management system. Please open a terminal and follow the instructions.
 
     ```shell
     conda create --name pyro-risks python=3.6 anaconda 
@@ -63,25 +64,30 @@ In order to contribute to project, you will first need to **set up your *pyro-ri
 
 #### 2. Fork the repository
 
-- We are going to get a local copy of the remote project (_fork_) and set remotes so we stay up to date to recent contributions.
+<br>
 
-  1. **Create a fork** by clicking on the **fork button** on the current repository page
-  2. Clone _your_ fork locally.
-    ```shell
-    # change directory to one for the project
-    cd /path/to/local/pyronear/project/
+-   We are going to get a local copy of the remote project (*fork*) and set remotes so we stay up to date to recent contributions.
 
-    # clone your fork. replace YOUR_USERNAME accordingly
-    git clone https://github.com/YOUR_USERNAME/pyro-risks.git
+    1.  **Create a fork** by clicking on the **fork button** on the current repository page
+    2.  Clone *your* fork locally.
 
-    # cd to pyro-risks
-    cd pyro-risks
-    ```
+        ```shell
+        # change directory to one for the project
+        cd /path/to/local/pyronear/project/
+
+        # clone your fork. replace YOUR_USERNAME accordingly
+        git clone https://github.com/YOUR_USERNAME/pyro-risks.git
+
+        # cd to pyro-risks
+        cd pyro-risks
+        ```
 
 #### 3. Set origin and upstream remotes repositories
 
-1. Configure your fork `YOUR_USERNAME/pyro-risks` as `origin` remote
-2. Configure `pyronear/pyro-risks` repository as `upstream` remote
+<br>
+
+1.  Configure your fork `YOUR_USERNAME/pyro-risks` as `origin` remote
+2.  Configure `pyronear/pyro-risks repository` as `upstream` remote
 
     ```shell
     # add the original repository as remote repository called "upstream"
@@ -100,8 +106,9 @@ In order to contribute to project, you will first need to **set up your *pyro-ri
     git merge upstream/master
     ```
 
-
 #### 4. Install project dependencies
+
+<br>
 
 ```shell
 # install dependencies
@@ -113,13 +120,14 @@ pip install -r requirements.txt
 pip install -e .
 ```
 
-
 ### Contributing workflow
----
+
+* * *
+
 Once the project is well set up, we are going to detail step by step a usual contributing workflow.
 
 1.  Merge recent contributions onto master (do this frequently to stay up-to-date)
-   
+
     ```shell
     # fetch all changes from the upstream repository
     git fetch upstream
@@ -131,7 +139,7 @@ Once the project is well set up, we are going to detail step by step a usual con
     git merge upstream/master
     ```
 
-    Note: Since, we are going to create features on separate local branches so they'll be merged onto **original project remote master** via pull requests, we may use **pulling** instead of fetching & merging. This way our **_local_ master branch** will reflect **_remote_ original project**. We don't expect to make changes on local master in this workflow so no conflict should arise when merging:
+    Note: Since, we are going to create features on separate local branches so they'll be merged onto **original project remote master** via pull requests, we may use **pulling** instead of fetching & merging. This way our **local master branch** will reflect **remote original project**. We don't expect to make changes on local master in this workflow so no conflict should arise when merging:
 
     ```shell
     # switch to local master
@@ -141,16 +149,16 @@ Once the project is well set up, we are going to detail step by step a usual con
     git pull upstream/master
     ```
 
-2. Create a local feature branch to work on
+2.  Create a local feature branch to work on
 
     ```shell
     # Create a new branch with the name of your feature
     git checkout -b feature-branch
     ```
 
-3. Commit your changes (remember to add unit tests for your code). Feel free to interactively rebase your history to improve readability. Follow the style guide See [Style Conventions](#style-conventions) to follow guidelines.
+3.  Commit your changes (remember to add unit tests for your code). Feel free to interactively rebase your history to improve readability. Follow the style guide See [Style Conventions](#style-conventions) to follow guidelines.
 
-4. Rebase your feature branch so that merging it will be a simple fast-forward that won't require any conflict resolution work.
+4.  Rebase your feature branch so that merging it will be a simple fast-forward that won't require any conflict resolution work.
 
     ```shell
     # Switch to feature branch
@@ -160,7 +168,8 @@ Once the project is well set up, we are going to detail step by step a usual con
     git rebase master
     ```
 
-5. Push your changes on remote feature branch.
+5.  Push your changes on remote feature branch.
+
     ```shell
     git checkout feature-branch
 
@@ -173,6 +182,4 @@ Once the project is well set up, we are going to detail step by step a usual con
     black /path/to/local/pyronear/project/pyro-risks/
     ```
 
-6. When satisfied with your branch, open a [PR](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork) from your fork in order to integrate your contribution to original project.
-
-
+6.  When satisfied with your branch, open a [PR](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork) from your fork in order to integrate your contribution to original project.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# pyronear-datascience
-Data science for wildfire risk and monitoring
+<h1 align="center">Pyronear Risks</h1>
+<p align="center">
+    <a href="LICENSE" alt="License">
+        <img src="https://img.shields.io/badge/License-GPLv3-blue.svg" /></a>
+      <a href="https://github.com/pyronear/pyro-vision/actions?query=workflow%3Apython-package">
+        <img src="https://github.com/pyronear/pyro-risks/workflows/python-package/badge.svg" /></a>
+   <a href="https://www.codacy.com/gh/pyronear/pyro-risks/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=pyronear/pyro-risks&amp;utm_campaign=Badge_Grade">
+      <img src="https://app.codacy.com/project/badge/Grade/3bea1a63e4aa44258cfd08831d713478" /></a>
+    <a href="https://codecov.io/gh/pyronear/pyro-risks">
+  		<img src="https://codecov.io/gh/pyronear/pyro-risks/branch/master/graph/badge.svg" /></a>
+    <a href="https://github.com/psf/black">
+        <img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
+    <a href="https://pyronear.github.io/pyro-risks">
+  		<img src="https://img.shields.io/badge/docs-available-blue.svg" /></a>
+</p>
+
+
+  Machine learning based wildifire risk forcasting

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 <p align="center">
     <a href="LICENSE" alt="License">
         <img src="https://img.shields.io/badge/License-GPLv3-blue.svg" /></a>
-      <a href="https://github.com/pyronear/pyro-vision/actions?query=workflow%3Apython-package">
+    <a href="https://github.com/pyronear/pyro-vision/actions?query=workflow%3Apython-package">
         <img src="https://github.com/pyronear/pyro-risks/workflows/python-package/badge.svg" /></a>
-   <a href="https://www.codacy.com/gh/pyronear/pyro-risks/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=pyronear/pyro-risks&amp;utm_campaign=Badge_Grade">
-      <img src="" /></a>
+   <a href="https://www.codacy.com/gh/pyronear/pyro-risks/dashboard?utm_source=github.com&utm_medium=referral&utm_content=pyronear/pyro-risks&utm_campaign=Badge_Grade">
+        <img src="https://camo.githubusercontent.com/6361a174bbd36acd5ee8c24b0ef27ba6a84803c2ac9354d57d60d1264d78a31a/68747470733a2f2f6170702e636f646163792e636f6d2f70726f6a6563742f62616467652f47726164652f6532623936393836356539663439633561623934343435643765346132613637" /></a>
     <a href="https://codecov.io/gh/pyronear/pyro-risks">
   		<img src="https://codecov.io/gh/pyronear/pyro-risks/branch/master/graph/badge.svg" /></a>
     <a href="https://github.com/psf/black">
@@ -13,7 +13,6 @@
     <a href="https://pyronear.github.io/pyro-risks">
   		<img src="https://img.shields.io/badge/docs-available-blue.svg" /></a>
 </p>
-
 
 The pyro-risks project aims at providing the pyronear-platform with a machine learning based wildifire risk forcasting capibility. 
 
@@ -31,14 +30,12 @@ The pyro-risks project aims at providing the pyronear-platform with a machine le
 - [Credits](#credits)
 - [License](#license)
 
-
-
 ## Getting started
 
 ### Prerequisites
 
-- Python 3.6 (or more recent)
-- [pip](https://pip.pypa.io/en/stable/)
+-   Python 3.6 (or more recent)
+-   [pip](https://pip.pypa.io/en/stable/)
 
 ### Installation
 
@@ -78,11 +75,9 @@ python scripts/example_ERA5_FIRMS.py --type_of_merged departements
 
 The full package documentation is available [here](https://pyronear.org/pyro-risks/) for detailed specifications. The documentation was built with [Sphinx](https://www.sphinx-doc.org) using a [theme](https://github.com/readthedocs/sphinx_rtd_theme) provided by [Read the Docs](https://readthedocs.org).
 
-
 ## Contributing
 
 Please refer to the [`CONTRIBUTING`](./CONTRIBUTING.md) guide if you wish to contribute to this project.
-
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   		<img src="https://img.shields.io/badge/docs-available-blue.svg" /></a>
 </p>
 
+The pyro-risks project aims at providing the pyronear-platform with a machine learning based wildifire risk forcasting capibility. 
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
       <a href="https://github.com/pyronear/pyro-vision/actions?query=workflow%3Apython-package">
         <img src="https://github.com/pyronear/pyro-risks/workflows/python-package/badge.svg" /></a>
    <a href="https://www.codacy.com/gh/pyronear/pyro-risks/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=pyronear/pyro-risks&amp;utm_campaign=Badge_Grade">
-      <img src="https://app.codacy.com/project/badge/Grade/3bea1a63e4aa44258cfd08831d713478" /></a>
+      <img src="" /></a>
     <a href="https://codecov.io/gh/pyronear/pyro-risks">
   		<img src="https://codecov.io/gh/pyronear/pyro-risks/branch/master/graph/badge.svg" /></a>
     <a href="https://github.com/psf/black">
@@ -15,4 +15,79 @@
 </p>
 
 
-  Machine learning based wildifire risk forcasting
+The pyro-risks project aims at providing the pyronear-platform with a machine learning based wildifire risk forcasting capibility. 
+
+## Table of Contents
+
+- [Table of Contents](#table-of-contents)
+- [Getting started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+- [Usage](#usage)
+  - [datasets](#datasets)
+- [Examples](#examples)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [Credits](#credits)
+- [License](#license)
+
+
+
+## Getting started
+
+### Prerequisites
+
+- Python 3.6 (or more recent)
+- [pip](https://pip.pypa.io/en/stable/)
+
+### Installation
+
+You can install the package from github as follows:
+
+```shell
+pip install git+git://github.com/pyronear/pyro-risks
+```
+
+## Usage
+
+### datasets
+
+Access all pyro-risks datasets. 
+
+```python
+from pyro_risks.datasets import NASAFIRMS, NOAAWeather
+firms = NASAFIRMS()
+noaa = NOAAWeather()
+```
+
+## Examples
+
+You are free to merge the datasets however you want and to implement any zonal statistic you want, but some are already provided for reference. In order to use them check the example scripts options as follows:
+
+```shell
+python scripts/example_ERA5_FIRMS.py --help
+```
+
+You can then run the script with your own arguments:
+
+```shell
+python scripts/example_ERA5_FIRMS.py --type_of_merged departements
+```
+
+## Documentation
+
+The full package documentation is available [here](https://pyronear.org/pyro-risks/) for detailed specifications. The documentation was built with [Sphinx](https://www.sphinx-doc.org) using a [theme](https://github.com/readthedocs/sphinx_rtd_theme) provided by [Read the Docs](https://readthedocs.org).
+
+
+## Contributing
+
+Please refer to the [`CONTRIBUTING`](./CONTRIBUTING.md) guide if you wish to contribute to this project.
+
+
+## Credits
+
+This project is developed and maintained by the repo owner and volunteers from [Data for Good](https://dataforgood.fr/).
+
+## License
+
+Distributed under the GPLv3 Licenses. See [`LICENSE`](./LICENSE) for more information.


### PR DESCRIPTION
This PR aims at improving the pyro-risks repository documentation. The documentation follows the same structure as the other pyronear projects:

- Update the README.md with title, badges, and short description
- Add CONTRIBUTING.md with fork setup, contribution worfkows and the repository style conventions

@frgfm I can access the Codacy panel for the pyro-risks repository [here](https://www.codacy.com/gh/pyronear/pyro-risks/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=pyronear/pyro-risks&amp;utm_campaign=Badge_Grade) but I can not access the grade badge image source link. Could you paste it just bellow please ? 