### PR TITLE
rewrite add_lags function to get faster execution

### DIFF
--- a/pyro_risks/models/predict.py
+++ b/pyro_risks/models/predict.py
@@ -5,10 +5,9 @@ from pyro_risks import config as cfg
 from pyro_risks.datasets.fwi import get_fwi_data_for_predict
 from pyro_risks.datasets.ERA5 import get_data_era5land_for_predict
 from pyro_risks.datasets.era_fwi_viirs import process_dataset_to_predict
-from pyro_risks.models.score_v0 import add_lags
+from pyro_risks.models.score_v0 import add_lags_to_predict
 
-
-__all__ = ['PyroRisk']
+__all__ = ["PyroRisk"]
 
 
 class PyroRisk(object):
@@ -21,15 +20,15 @@ class PyroRisk(object):
         object ([type])
     """
 
-    def __init__(self, which='RF'):
+    def __init__(self, which="RF"):
         """Load from Github release the trained model. For the moment only RF and XGB are available.
 
         Args:
             which (str, optional): Can be 'RF' for random forest or 'XGB' for xgboost. Defaults to 'RF'.
         """
-        if which == 'RF':
+        if which == "RF":
             self.model_path = cfg.RFMODEL_PATH
-        elif which == 'XGB':
+        elif which == "XGB":
             self.model_path = cfg.XGBMODEL_PATH
         self.model = joblib.load(urlopen(self.model_path))
 
@@ -49,15 +48,17 @@ class PyroRisk(object):
         fwi = get_fwi_data_for_predict(day)
         era = get_data_era5land_for_predict(day)
         res_test = process_dataset_to_predict(fwi, era)
-        res_test = res_test.rename({'nom': 'departement'}, axis=1)
-        res_lags = add_lags(res_test, res_test.drop(['day', 'departement'], axis=1).columns)
-        to_predict = res_lags.loc[res_lags['day'] == day]
-        to_predict = to_predict.drop('day', axis=1).set_index('departement')
+        res_test = res_test.rename({"nom": "departement"}, axis=1)
+        res_lags = add_lags_to_predict(
+            res_test, res_test.drop(["day", "departement"], axis=1).columns
+        )
+        to_predict = res_lags.loc[res_lags["day"] == day]
+        to_predict = to_predict.drop("day", axis=1).set_index("departement")
         # Some NaN due to the aggregations on departments with only one line (variables with std)
         to_predict = to_predict.fillna(0)
         return to_predict[model_cols]
 
-    def predict(self, day, country='France'):
+    def predict(self, day, country="France"):
         """Serves a prediction for the specified day.
 
         Note that predictions on fwi and era5land data queried from CDS API will return 93 departments
@@ -73,4 +74,4 @@ class PyroRisk(object):
         sample = self.get_input(day)
         predictions = self.model.predict_proba(sample.values)
         res = dict(zip(sample.index, predictions[:, 1].round(3)))
-        return {x: {'score': res[x], 'explainability': None} for x in res}
+        return {x: {"score": res[x], "explainability": None} for x in res}

--- a/pyro_risks/models/predict.py
+++ b/pyro_risks/models/predict.py
@@ -6,7 +6,7 @@ from pyro_risks import config as cfg
 from pyro_risks.datasets.fwi import get_fwi_data_for_predict
 from pyro_risks.datasets.ERA5 import get_data_era5land_for_predict, get_data_era5t_for_predict
 from pyro_risks.datasets.era_fwi_viirs import process_dataset_to_predict
-from pyro_risks.models.score_v0 import add_lags_to_predict
+from pyro_risks.models.score_v0 import add_lags_to_predict, add_lags
 
 __all__ = ["PyroRisk"]
 
@@ -55,7 +55,7 @@ class PyroRisk(object):
         res_test = res_test.rename({'nom': 'departement'}, axis=1)
         # Add lags only for columns on which model was trained on
         cols_lags = ['_'.join(x.split('_')[:-1]) for x in cfg.MODEL_ERA5T_VARS if '_lag' in x]
-        res_lags = add_lags(res_test, cols_lags)
+        res_lags = add_lags_to_predict(res_test, cols_lags)
         # Select only rows corresponding to day
         to_predict = res_lags.loc[res_lags['day'] == day]
         to_predict = to_predict.drop('day', axis=1).set_index('departement')

--- a/pyro_risks/models/score_v0.py
+++ b/pyro_risks/models/score_v0.py
@@ -6,7 +6,6 @@ import xgboost as xgb
 import pandas as pd
 import numpy as np
 
-
 __all__ = [
     "prepare_dataset",
     "target_correlated_features",
@@ -15,7 +14,6 @@ __all__ = [
     "train_random_forest",
     "xgb_model",
 ]
-
 
 SELECTED_DEP = [
     "Aisne",
@@ -43,7 +41,6 @@ SELECTED_DEP = [
     "Somme",
     "Yonne",
 ]
-
 
 RF_PARAMS = {
     "n_estimators": 500,
@@ -141,6 +138,7 @@ def add_lags_to_predict(df, cols):
         # therefore J-7 data is at the 3rd position
         df[f"{feature}_lag7"] = df[feature].shift(-3)
     return df
+
 
 def add_lags(df, cols):
     """Add lags to dataframe df of the selected columns.

--- a/pyro_risks/models/score_v0.py
+++ b/pyro_risks/models/score_v0.py
@@ -120,9 +120,10 @@ def split_train_test(X, y):
     return X_train, X_test, y_train, y_test
 
 
-def add_lags(df, cols):
-    """Add lags to dataframe df of the selected columns.
+def add_lags_to_predict(df, cols):
+    """Add lags to dataframe df of the selected columns for prediction purposes.
 
+    This function is to be used ONLY in the predict pipeline.
     Lags added correspond to day -1, -3 and -7 and are added to each department separately.
 
     Args:
@@ -139,6 +140,36 @@ def add_lags(df, cols):
         # 4 and not 7 because we only have values of J, J-1, J-3 and J-7
         # therefore J-7 data is at the 3rd position
         df[f"{feature}_lag7"] = df[feature].shift(-3)
+    return df
+
+
+def add_lags(df, cols):
+    """Add lags to dataframe df of the selected columns.
+
+    Lags added correspond to day -1, -3 and -7 and are added to each department separately.
+
+    Args:
+        df (pd.DataFrame): main dataframe with departement and day columns
+        cols (list of str): columns on which to add lags
+
+    Returns:
+        [type]: [description]
+    """
+    for var in cols:
+        for dep in df["departement"].unique():
+            tmp = df[df["departement"] == dep][["day", var]].set_index("day")
+            tmp1 = tmp.copy()
+            tmp1 = tmp1.join(
+                tmp.shift(periods=1, freq="D"), rsuffix="_lag1", how="left"
+            )
+            tmp1 = tmp1.join(
+                tmp.shift(periods=3, freq="D"), rsuffix="_lag3", how="left"
+            )
+            tmp1 = tmp1.join(
+                tmp.shift(periods=7, freq="D"), rsuffix="_lag7", how="left"
+            )
+            new_vars = [var + "_lag1", var + "_lag3", var + "_lag7"]
+            df.loc[df["departement"] == dep, new_vars] = tmp1[new_vars].values
     return df
 
 

--- a/pyro_risks/models/score_v0.py
+++ b/pyro_risks/models/score_v0.py
@@ -142,7 +142,6 @@ def add_lags_to_predict(df, cols):
         df[f"{feature}_lag7"] = df[feature].shift(-3)
     return df
 
-
 def add_lags(df, cols):
     """Add lags to dataframe df of the selected columns.
 
@@ -160,13 +159,19 @@ def add_lags(df, cols):
             tmp = df[df["departement"] == dep][["day", var]].set_index("day")
             tmp1 = tmp.copy()
             tmp1 = tmp1.join(
-                tmp.shift(periods=1, freq="D"), rsuffix="_lag1", how="left"
+                tmp.shift(periods=1, freq=np.timedelta64(1, "D")),
+                rsuffix="_lag1",
+                how="left",
             )
             tmp1 = tmp1.join(
-                tmp.shift(periods=3, freq="D"), rsuffix="_lag3", how="left"
+                tmp.shift(periods=3, freq=np.timedelta64(1, "D")),
+                rsuffix="_lag3",
+                how="left",
             )
             tmp1 = tmp1.join(
-                tmp.shift(periods=7, freq="D"), rsuffix="_lag7", how="left"
+                tmp.shift(periods=7, freq=np.timedelta64(1, "D")),
+                rsuffix="_lag7",
+                how="left",
             )
             new_vars = [var + "_lag1", var + "_lag3", var + "_lag7"]
             df.loc[df["departement"] == dep, new_vars] = tmp1[new_vars].values

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -136,13 +136,13 @@ class ModelsTester(unittest.TestCase):
         pr = predict.PyroRisk(which="RF")
         self.assertEqual(pr.model.n_estimators, 500)
         self.assertEqual(pr.model_path, cfg.RFMODEL_ERA5T_PATH)
-        res = pr.get_input('2020-05-05')
+        res = pr.get_input("2020-05-05")
         self.assertIsInstance(res, pd.DataFrame)
         self.assertEqual(res.shape, (93, 40))
-        preds = pr.predict('2020-05-05')
+        preds = pr.predict("2020-05-05")
         self.assertEqual(len(preds), 93)
-        self.assertEqual(preds['Ardennes'], {'score': 0.246, 'explainability': None})
+        self.assertEqual(preds["Ardennes"], {"score": 0.246, "explainability": None})
 
-        
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -43,7 +43,7 @@ class ModelsTester(unittest.TestCase):
             score_v0.target_correlated_features(X, y), ["str_mean", "isi_mean"]
         )
 
-    def test_add_lags(self):
+    def test_add_lags_to_predict(self):
         df = pd.DataFrame(
             {
                 "day": ["2019-07-01", "2019-07-04", "2019-07-07", "2019-07-08"],
@@ -65,6 +65,32 @@ class ModelsTester(unittest.TestCase):
                 "fwi_mean_lag1": {3: 0.9, 2: 13.3, 1: 1.1, 0: np.nan},
                 "fwi_mean_lag3": {3: 13.3, 2: 1.1, 1: np.nan, 0: np.nan},
                 "fwi_mean_lag7": {3: 1.1, 2: np.nan, 1: np.nan, 0: np.nan},
+            }
+        )
+        assert_frame_equal(res, score_v0.add_lags(df, ["fwi_mean"]))
+
+    def test_add_lags(self):
+        df = pd.DataFrame(
+            {
+                "day": ["2019-07-01", "2019-07-04", "2019-07-07", "2019-07-08"],
+                "departement": ["Cantal", "Cantal", "Cantal", "Cantal"],
+                "fwi_mean": [1.1, 13.3, 0.9, 2.5],
+            }
+        )
+        df["day"] = pd.to_datetime(df["day"])
+        res = pd.DataFrame(
+            {
+                "day": {
+                    0: np.datetime64("2019-07-01"),
+                    1: np.datetime64("2019-07-04"),
+                    2: np.datetime64("2019-07-07"),
+                    3: np.datetime64("2019-07-08"),
+                },
+                "departement": {0: "Cantal", 1: "Cantal", 2: "Cantal", 3: "Cantal"},
+                "fwi_mean": {0: 1.1, 1: 13.3, 2: 0.9, 3: 2.5},
+                "fwi_mean_lag1": {0: np.nan, 1: np.nan, 2: np.nan, 3: 0.9},
+                "fwi_mean_lag3": {0: np.nan, 1: 1.1, 2: 13.3, 3: np.nan},
+                "fwi_mean_lag7": {0: np.nan, 1: np.nan, 2: np.nan, 3: 1.1},
             }
         )
         assert_frame_equal(res, score_v0.add_lags(df, ["fwi_mean"]))

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 import pandas as pd
+from pandas._libs.tslibs.timestamps import Timestamp
 from pandas.testing import assert_frame_equal, assert_series_equal
 from sklearn.datasets import load_breast_cancer
 
@@ -12,80 +13,109 @@ from pyro_risks import config as cfg
 class ModelsTester(unittest.TestCase):
     def test_prepare_dataset(self):
         df = pd.DataFrame(
-            {'day': ['2019-07-01', '2019-08-02', '2019-06-12'],
-             'departement': ['Aisne', 'Cantal', 'Savoie'],
-             'fires': [0, 5, 10],
-             'fwi_mean': [13.3, 0.9, 2.5],
-             'ffmc_max': [23, 45.3, 109.]
-             })
-        X, y = score_v0.prepare_dataset(df, selected_dep=['Aisne', 'Cantal'])
+            {
+                "day": ["2019-07-01", "2019-08-02", "2019-06-12"],
+                "departement": ["Aisne", "Cantal", "Savoie"],
+                "fires": [0, 5, 10],
+                "fwi_mean": [13.3, 0.9, 2.5],
+                "ffmc_max": [23, 45.3, 109.0],
+            }
+        )
+        X, y = score_v0.prepare_dataset(df, selected_dep=["Aisne", "Cantal"])
         assert_frame_equal(
-            X, pd.DataFrame({'ffmc_max': {0: 23.0, 1: 45.3}, 'fwi_mean': {0: 13.3, 1: 0.9}}))
-        assert_series_equal(y, pd.Series([0, 1], name='classif_target'))
+            X,
+            pd.DataFrame(
+                {"ffmc_max": {0: 23.0, 1: 45.3}, "fwi_mean": {0: 13.3, 1: 0.9}}
+            ),
+        )
+        assert_series_equal(y, pd.Series([0, 1], name="classif_target"))
 
     def test_target_correlated_features(self):
         X = pd.DataFrame(
-            {'str_mean': [2, 3, 4, 0, 0], 'ffmc_min': [0, 0, 0, 0, 0], 'isi_mean': [3, 0, 1, 4, 5]}
+            {
+                "str_mean": [2, 3, 4, 0, 0],
+                "ffmc_min": [0, 0, 0, 0, 0],
+                "isi_mean": [3, 0, 1, 4, 5],
+            }
         )
-        y = pd.Series(np.array([1, 1, 1, 0, 0]), name='classif_target')
-        self.assertEqual(score_v0.target_correlated_features(X, y), ['str_mean', 'isi_mean'])
+        y = pd.Series(np.array([1, 1, 1, 0, 0]), name="classif_target")
+        self.assertEqual(
+            score_v0.target_correlated_features(X, y), ["str_mean", "isi_mean"]
+        )
 
     def test_add_lags(self):
         df = pd.DataFrame(
-            {'day': ['2019-07-01', '2019-07-04', '2019-07-07', '2019-07-08'],
-             'departement': ['Cantal', 'Cantal', 'Cantal', 'Cantal'],
-             'fwi_mean': [1.1, 13.3, 0.9, 2.5],
-             })
-        df['day'] = pd.to_datetime(df['day'])
-        res = pd.DataFrame({'day': {0: np.datetime64('2019-07-01'),
-                                    1: np.datetime64('2019-07-04'),
-                                    2: np.datetime64('2019-07-07'),
-                                    3: np.datetime64('2019-07-08')},
-                            'departement': {0: 'Cantal', 1: 'Cantal', 2: 'Cantal', 3: 'Cantal'},
-                            'fwi_mean': {0: 1.1, 1: 13.3, 2: 0.9, 3: 2.5},
-                            'fwi_mean_lag1': {0: np.nan, 1: np.nan, 2: np.nan, 3: 0.9},
-                            'fwi_mean_lag3': {0: np.nan, 1: 1.1, 2: 13.3, 3: np.nan},
-                            'fwi_mean_lag7': {0: np.nan, 1: np.nan, 2: np.nan, 3: 1.1}})
-        assert_frame_equal(res, score_v0.add_lags(df, ['fwi_mean']))
+            {
+                "day": ["2019-07-01", "2019-07-04", "2019-07-07", "2019-07-08"],
+                "departement": ["Cantal", "Cantal", "Cantal", "Cantal"],
+                "fwi_mean": [1.1, 13.3, 0.9, 2.5],
+            }
+        )
+        df["day"] = pd.to_datetime(df["day"])
+        res = pd.DataFrame(
+            {
+                "day": {
+                    3: Timestamp("2019-07-08 00:00:00"),
+                    2: Timestamp("2019-07-07 00:00:00"),
+                    1: Timestamp("2019-07-04 00:00:00"),
+                    0: Timestamp("2019-07-01 00:00:00"),
+                },
+                "departement": {3: "Cantal", 2: "Cantal", 1: "Cantal", 0: "Cantal"},
+                "fwi_mean": {3: 2.5, 2: 0.9, 1: 13.3, 0: 1.1},
+                "fwi_mean_lag1": {3: 0.9, 2: 13.3, 1: 1.1, 0: np.nan},
+                "fwi_mean_lag3": {3: 13.3, 2: 1.1, 1: np.nan, 0: np.nan},
+                "fwi_mean_lag7": {3: 1.1, 2: np.nan, 1: np.nan, 0: np.nan},
+            }
+        )
+        assert_frame_equal(res, score_v0.add_lags(df, ["fwi_mean"]))
 
     def test_split_train_test(self):
-        X = pd.DataFrame({'ffmc_min': [0, 1, 2, 3, 4], 'strd_max': [1, 1, 3, 3, 5]})
-        y = pd.Series([0, 0, 0, 1, 1], name='classif_target')
+        X = pd.DataFrame({"ffmc_min": [0, 1, 2, 3, 4], "strd_max": [1, 1, 3, 3, 5]})
+        y = pd.Series([0, 0, 0, 1, 1], name="classif_target")
         X_train, X_test, y_train, y_test = score_v0.split_train_test(X, y)
-        assert_frame_equal(X_train,
-                           pd.DataFrame(
-                               {'ffmc_min': {4: 4, 2: 2, 0: 0, 3: 3},
-                                'strd_max': {4: 5, 2: 3, 0: 1, 3: 3}}))
-        assert_frame_equal(X_test,
-                           pd.DataFrame(
-                               {'ffmc_min': {1: 1}, 'strd_max': {1: 1}}))
-        assert_series_equal(y_train, pd.Series({4: 1, 2: 0, 0: 0, 3: 1}, name='classif_target'))
-        assert_series_equal(y_test, pd.Series({1: 0}, name='classif_target'))
+        assert_frame_equal(
+            X_train,
+            pd.DataFrame(
+                {
+                    "ffmc_min": {4: 4, 2: 2, 0: 0, 3: 3},
+                    "strd_max": {4: 5, 2: 3, 0: 1, 3: 3},
+                }
+            ),
+        )
+        assert_frame_equal(
+            X_test, pd.DataFrame({"ffmc_min": {1: 1}, "strd_max": {1: 1}})
+        )
+        assert_series_equal(
+            y_train, pd.Series({4: 1, 2: 0, 0: 0, 3: 1}, name="classif_target")
+        )
+        assert_series_equal(y_test, pd.Series({1: 0}, name="classif_target"))
 
     def test_train_random_forest(self):
         data = load_breast_cancer()
-        a, b, c, d = score_v0.split_train_test(data['data'], data['target'])
+        a, b, c, d = score_v0.split_train_test(data["data"], data["target"])
         rfc = score_v0.train_random_forest(a, b, c, d)
         self.assertEqual(rfc.predict(b[:1]), np.array([1]))
         self.assertEqual(rfc.score(b, d), 0.9736842105263158)
 
     def test_xgb_model(self):
         data = load_breast_cancer()
-        a, b, c, d = score_v0.split_train_test(data['data'], data['target'])
-        _, _, preds = score_v0.xgb_model(a, c, b, d, params={'min_child_weight': 5, 'eta': .1})
+        a, b, c, d = score_v0.split_train_test(data["data"], data["target"])
+        _, _, preds = score_v0.xgb_model(
+            a, c, b, d, params={"min_child_weight": 5, "eta": 0.1}
+        )
         self.assertEqual(len(preds), 114)
         self.assertEqual(preds[0].round(3), np.float32(0.996))
 
     def test_pyrorisk(self):
-        pr = predict.PyroRisk(which='RF')
+        pr = predict.PyroRisk(which="RF")
         self.assertEqual(pr.model.n_estimators, 500)
         self.assertEqual(pr.model_path, cfg.RFMODEL_PATH)
-        res = pr.get_input('2020-05-05')
+        res = pr.get_input("2020-05-05")
         self.assertIsInstance(res, pd.DataFrame)
         self.assertEqual(res.shape, (93, 41))
-        preds = pr.predict('2020-05-05')
+        preds = pr.predict("2020-05-05")
         self.assertEqual(len(preds), 93)
-        self.assertEqual(preds['Ardennes'], {'score': 0.11, 'explainability': None})
+        self.assertEqual(preds["Ardennes"], {"score": 0.11, "explainability": None})
 
 
 if __name__ == "__main__":

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -67,7 +67,7 @@ class ModelsTester(unittest.TestCase):
                 "fwi_mean_lag7": {3: 1.1, 2: np.nan, 1: np.nan, 0: np.nan},
             }
         )
-        assert_frame_equal(res, score_v0.add_lags(df, ["fwi_mean"]))
+        assert_frame_equal(res, score_v0.add_lags_to_predict(df, ["fwi_mean"]))
 
     def test_add_lags(self):
         df = pd.DataFrame(


### PR DESCRIPTION
Hello people, this PR aims at:

- rewriting `add_lags` function to make it faster.
- edit style of the script containing this function.
- change the `test_add_lags` to make it correspond with the new function (it doesn't work like the previous one and therefore does not output the same thing but at the end, the `to_predict` dataframes are the same + all other tests are ok)
- edit style of the script `test_models.py`

Next steps:
- find a way to make `get_fwi_data_for_predict` faster because it's the function which takes too much time.

**Previously**: 

time execution logs for old version of `add_lags`
![image](https://user-images.githubusercontent.com/57073096/102129138-2e983e80-3e4f-11eb-8b0c-e2e648cd06c4.png)
and
![image](https://user-images.githubusercontent.com/57073096/102129218-4b347680-3e4f-11eb-941b-e602e5a059e6.png)


**Now**: 

![image](https://user-images.githubusercontent.com/57073096/102129820-4a501480-3e50-11eb-99e7-fb85bf08cbb2.png)

![image](https://user-images.githubusercontent.com/57073096/102129270-5d161980-3e4f-11eb-81e9-ffd5bfa9cde3.png)

![image](https://user-images.githubusercontent.com/57073096/102129675-0ceb8700-3e50-11eb-9ae8-1a6b8afd2ca5.png)

