### PR TITLE
ci: Updated funding from OpenCollective to Github

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,8 +1,8 @@
 # These are supported funding model platforms
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: pyronear
 patreon: # Replace with a single Patreon username
-open_collective: pyronear
+open_collective: # Replace with an OpenCollective account
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry


### PR DESCRIPTION
This PR changes the funding method from OpenCollective to Github Sponsor.

Any feedback is welcome!