### PR TITLE
S3 enhanced

### DIFF
--- a/pyro_risks/notebooks/s3_tutorial.ipynb
+++ b/pyro_risks/notebooks/s3_tutorial.ipynb
@@ -1,0 +1,262 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# S3 submodule tutorial"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Welcome to the S3 submodule tutorial. This tutorial will walk you through the basics of using the S3 submodule to interact with the risk S3 buckets."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our data are stored in aws s3 buckets, which need to be accessed either using the aws cli or the boto3 python library. The S3 submodule provides a simple interface to the s3 buckets, allowing you to easily interact with the buckets using only python."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, one needs to add temporary the directory containing the submodule to the path. This can be done by adding the following lines to the beginning of the notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "sys.path.append(\"../utils\")\n",
+    "from s3 import S3Bucket, read_credentials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then, we need to load your credentials. These should NEVER be directly written in your code.\n",
+    "Depending on your OS or the way you saved the credentials for the aws cli, the file \"credentials\" should be located in one of the following directories of the next cell. \n",
+    "\n",
+    "Please change the path accordingly if you are not using a linux machine or if you saved the credentials in a different directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if sys.platform == \"win32\":  # Windows\n",
+    "    credentials_path = r\"C:\\Users\\Jules\\.aws\\\\\"  # Change Jules to your username\n",
+    "else:  # Linux or MacOS\n",
+    "    credentials_path = r\"~/.aws/\"\n",
+    "\n",
+    "credentials = read_credentials(credentials_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then, we can create a S3Bucket object and use it to upload and download files from S3 for instance.\n",
+    "\n",
+    "By default, the bucket's name is \"risk\". "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = S3Bucket(bucket_name=\"risk\", **credentials)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## s3 submodule usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section is not exhaustive, but it should give you a good idea of how to use the S3Bucket class. For more information, please refer directly to the docstrings."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to list folders in the bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Example 1 : ['Old/', 'datacube/', 'datasets_grl/']\n",
+      "Example 2 : ['Old/ERA5Land/', 'Old/FWI/', 'Old/Historiques_feux/', 'Old/MODIS_LST/', 'Old/MODIS_NDVI/', 'Old/Old/', 'Old/Roads_distance/', 'Old/SAMPLE/', 'Old/SMI/', 'Old/Waterway_distance/', 'Old/Yearly_population/', 'Old/copernicus_elevation_and_slope/']\n"
+     ]
+    }
+   ],
+   "source": [
+    "_ = bucket.list_folders(prefix=\"\", delimiter=\"/\")\n",
+    "print(\"Example 1 :\", _)\n",
+    "_ = bucket.list_folders(prefix=_[0], delimiter=\"/\")\n",
+    "print(\"Example 2 :\", _)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Knowing the folder structure of the bucket, we can now list the files in a folder. \n",
+    "\n",
+    "For example, we can list the files in the folder \"Old/\", with .csv or .txt in their name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "50\n"
+     ]
+    }
+   ],
+   "source": [
+    "_ = bucket.list_files(\n",
+    "    prefix=\"Old/\", patterns=[\".csv\", \".txt\"]\n",
+    ")  # patterns can also be a part of the filename\n",
+    "print(len(_))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Following the same procedure, we can list files' metadata such as their size, last modified date. Or get all the metadata only file by file by using prefix for the whole file path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Example 1 : {'file_name': 'Old/ERA5Land/2022.csv', 'file_size': 611202.47, 'file_last_modified': datetime.datetime(2023, 9, 10, 17, 21, 47, tzinfo=tzutc())}\n",
+      "Example 2 : [{'file_name': 'Old/ERA5Land/2022.csv', 'file_size': 611202.47, 'file_last_modified': datetime.datetime(2023, 9, 10, 17, 21, 47, tzinfo=tzutc())}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "_ = bucket.get_files_metadata(prefix=\"Old/\", patterns=[\".csv\", \".txt\"])\n",
+    "print(\"Example 1 :\", _[0])\n",
+    "_ = bucket.get_files_metadata(prefix=\"Old/ERA5Land/2022.csv\")\n",
+    "print(\"Example 2 :\", _)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One can also donwload a whole folder from the bucket. The prefix will be used to filter the files to download. The whole architecture of the folder and its parent will be recreated locally. \n",
+    "\n",
+    "The ``save_path`` optional argument will be used if you need to save the folder in a specific location. Otherwise, the folder will be saved in the current working directory. Let's say if you need to have multiple versions of the same folder, you can use the ``save_path`` argument to save them in different locations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket.download_folder(prefix=\"Old/ERA5Land/\", save_path=\"Version_1/\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using only the path of a certain file and the name you want to give it, you can download a file with : "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket.download_file(\"Old/ERA5Land/2022.csv\", \"2022.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If needed, you need the key of the file to delete it. \n",
+    "By the same way, you can upload a file by specifying its local file path and the key you want to assign. Keep in mind that the key is the path of the file in the bucket and the name you want to give it.\n",
+    "\n",
+    "The functions are ``upload_file`` and ``delete_file``."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pyronear",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pyro_risks/utils/s3.py
+++ b/pyro_risks/utils/s3.py
@@ -1,4 +1,5 @@
 import boto3
+import os
 
 __all__ = ["S3Bucket"]
 
@@ -30,6 +31,10 @@ class S3Bucket:
 
         >>> s3.download_file('path/to/my_file.txt', 'my_downloaded_file.txt')
 
+        To download a folder from the bucket, use:
+
+        >>> s3.download_folder('path/to/my_folder', 'my_downloaded_folder')
+
         To delete a file from the bucket, use:
 
         >>> s3.delete_file('path/to/my_file.txt')
@@ -40,11 +45,15 @@ class S3Bucket:
 
         To filter files by a pattern, use:
 
-        >>> pattern_files = s3.list_files(pattern='my_prefix')
+        >>> pattern_files = s3.list_files(patterns=["pattern1", "pattern2"])
 
         To get metadata for a file in the bucket, use:
 
         >>> metadata = s3.get_file_metadata('path/to/my_file.txt')
+
+        To get file size and last modified date for some files in the bucket, use:
+
+        >>> files_metadata = s3.get_files_metadata(prefix="path/to/my_folder_or_file")
     """
 
     def __init__(
@@ -74,6 +83,7 @@ class S3Bucket:
         self.session = boto3.Session(**session_args)
         self.s3 = self.session.resource("s3", endpoint_url=endpoint_url)
         self.bucket = self.s3.Bucket(bucket_name)
+        self.bucket_name = bucket_name
 
     def upload_file(self, file_path: str, object_key: str) -> None:
         """
@@ -95,6 +105,21 @@ class S3Bucket:
         """
         self.bucket.download_file(object_key, file_path)
 
+    def download_folder(self, prefix: str, save_path: str = "") -> None:
+        """
+        Downloads a folder from the S3 bucket.
+
+        Args:
+            prefix (str): The S3 key (path) of the folder to download.
+            save_path (str, optional): The local folder where the folder tree will be saved.
+        """
+        if save_path != "" and not (save_path.endswith("/")):
+            save_path += "/"
+        for obj in self.bucket.objects.filter(Prefix=prefix):
+            if not os.path.exists(os.path.dirname(save_path + obj.key)):
+                os.makedirs(os.path.dirname(save_path + obj.key))
+            self.bucket.download_file(obj.key, save_path + obj.key)
+
     def delete_file(self, object_key: str) -> None:
         """
         Deletes a file from the S3 bucket.
@@ -104,19 +129,43 @@ class S3Bucket:
         """
         self.bucket.Object(object_key).delete()
 
-    def list_files(self, pattern: str = None) -> list[str]:
+    def list_folders(self, prefix: str = "", delimiter: str = "") -> list[str]:
+        """
+        Lists folders in the S3 bucket.
+
+        Args:
+            prefix (str, optional): Only folders with keys starting with this prefix will be listed.
+            delimiter (str, optional): The delimiter to use for the folder listing.
+
+        Returns:
+            A list of folder keys (paths) in the bucket.
+        """
+        folders = []
+        for obj in self.bucket.meta.client.list_objects_v2(
+            Bucket=self.bucket_name, Prefix=prefix, Delimiter=delimiter
+        )["CommonPrefixes"]:
+            folders.append(obj["Prefix"])
+        return folders
+
+    def list_files(
+        self, patterns: list[str] = None, prefix: str = "", delimiter: str = ""
+    ) -> list[str]:
         """
         Lists files in the S3 bucket.
 
         Args:
-            pattern (str): The pattern to filter files by (optional).
+            patterns (list[str], optional): Only files with keys containing one of the patterns will be listed.
+            prefix (str, optional): Only folders with keys starting with this prefix will be listed.
+            delimiter (str, optional): The delimiter to use for the folder listing.
 
         Returns:
             A list of file keys (paths) in the bucket.
         """
         files = []
-        for obj in self.bucket.objects.all():
-            if not pattern or pattern in obj.key:
+        for obj in self.bucket.objects.filter(Prefix=prefix, Delimiter=delimiter):
+            if not patterns or (
+                type(patterns) == list and any([p in obj.key for p in patterns])
+            ):
                 files.append(obj.key)
         return files
 
@@ -134,24 +183,62 @@ class S3Bucket:
         metadata = obj.metadata
         return metadata
 
-    def get_files_metadata(self, pattern: str = None) -> dict:
+    def get_files_metadata(
+        self, patterns: list[str] = None, prefix: str = "", delimiter: str = ""
+    ) -> list[dict]:
         """
         Lists files in the S3 bucket with their size in bytes and last modified dates.
 
         Args:
-            pattern (str): The pattern to filter files by (optional).
+            patterns (list[str], optional): Only files with keys containing one of the patterns will be listed.
+            prefix (str, optional): Only folders with keys starting with this prefix will be listed.
+            delimiter (str, optional): The delimiter to use for the folder listing.
 
         Returns:
             A dictionnary of file keys (paths), file sizes en GB and last modified dates in the bucket.
         """
         files = []
-        for obj in self.bucket.objects.all():
-            if not pattern or pattern in obj.key:
+        for obj in self.bucket.objects.filter(Prefix=prefix, Delimiter=delimiter):
+            if not patterns or (
+                type(patterns) == list and any([p in obj.key for p in patterns])
+            ):
                 files.append(
                     {
                         "file_name": obj.key,
-                        "file_size": round(obj.size * 1.0 / (1024), 2), 
+                        "file_size": round(obj.size * 1.0 / (1024), 2),
                         "file_last_modified": obj.last_modified,
                     }
                 )
         return files
+
+
+def read_credentials(
+    credentials_path: str,
+) -> dict:
+    """
+    Retrieves credentials from a file.
+
+    Args:
+        credentials_path (str): The path of the file containing the credentials.
+
+    Returns:
+        A dictionary containing the credentials for aws s3 access.
+    """
+    credentials = {}
+    with open(credentials_path + "credentials", "r") as f:
+        lines = f.readlines()
+        for line in lines:
+            if "aws_access_key_id" in line:
+                credentials["aws_access_key_id"] = line.split("=")[1].strip()
+            if "aws_secret_access_key" in line:
+                credentials["aws_secret_key"] = line.split("=")[1].strip()
+
+    with open(credentials_path + "config", "r") as f:
+        lines = f.readlines()
+        for line in lines:
+            if "region" in line:
+                credentials["region_name"] = line.split("=")[1].strip()
+    credentials["endpoint_url"] = (
+        "https://s3." + credentials["region_name"] + ".io.cloud.ovh.net/"
+    )
+    return credentials


### PR DESCRIPTION
As the S3 bucket got heavier recently, most of the functions could not work as they were listing all files. Some functions were also needed in order to avoid switching between the workflow of aws CLI and boto3.

- add list_folders method to S3Bucket class

- add download_folder method to S3Bucket class

- refactor widely list_files to allow more flexible use

- modify get_files_metadata in order to add the same flexibility as list_files

- add a read_credentials (not in S3Bucket class) to read the credentials : this avoids redundancy

These functions are also explained in a notebook.

- add a notebook s3_tutorial  to facilitate use of the sub-module by new contributors.